### PR TITLE
ABX-5951 Update base CallBuilder class to substitute 'https'

### DIFF
--- a/src/call_builder.js
+++ b/src/call_builder.js
@@ -34,7 +34,7 @@ export class CallBuilder {
       //append filters to original segments
       let newSegment = this.originalSegments.concat(this.filter[0]);
       this.url.segment(newSegment);
-    }        
+    }
   }
 
   /**
@@ -132,7 +132,7 @@ export class CallBuilder {
 
       return this._sendNormalRequest(uri).then(r => this._parseResponse(r));
     };
-  } 
+  }
 
   /**
    * Convert each link into a function on the response object.
@@ -194,11 +194,11 @@ export class CallBuilder {
     return {
       records: json._embedded.records,
       next: () => {
-        return this._sendNormalRequest(URI(json._links.next.href))
+        return this._sendNormalRequest(URI(json._links.next.href.replace('http:', 'https:')))
           .then(r => this._toCollectionPage(r));
       },
       prev: () => {
-        return this._sendNormalRequest(URI(json._links.prev.href))
+        return this._sendNormalRequest(URI(json._links.prev.href.replace('http:', 'https:')))
           .then(r => this._toCollectionPage(r));
       }
     };


### PR DESCRIPTION
ABX-5951 Update base CallBuilder class to substitute 'https' for 'http' calls by default when generating links for 'next' method